### PR TITLE
Update ALS for Factorio 0.0.13

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,4 +1,3 @@
-require "defines"
 require "gui"
 require "interface"
 
@@ -789,7 +788,7 @@ end
 function getDisconnectedChests(force)
     local type = "logistic-container"
     local disconnected = {}
-    local surface = game.get_surface(1)
+    local surface = game.surfaces[1]
 
     for coord in surface.get_chunks() do
         local X,Y = coord.x, coord.y
@@ -825,7 +824,7 @@ end
 -- takes an entity position, an int radius and force as parameters
 function findDisconnectedChests(pos, radius, force)
     local type = "logistic-container"
-    local surface = game.get_surface(1)
+    local surface = game.surfaces[1]
     local disconnected = global.disconnectedChests[force.name]
 
     local area = {{pos.x-radius, pos.y-radius}, {pos.x+radius, pos.y+radius}}
@@ -896,7 +895,7 @@ end
 -- takes entity and force name as parameters
 function inLogisticsNetwork(entity, force, ret)
     local pos = entity.position
-    local surface = entity.surface and entity.surface or game.get_surface(1)
+    local surface = entity.surface and entity.surface or game.surfaces[1]
     local network = surface.find_logistic_network_by_position(pos, force)
 
     return not ret and network ~= nil or ret and network
@@ -907,7 +906,7 @@ end
 function getNormalChests(force)
     local types = {"container", "smart-container"}
     local chests = {}
-    local surface = game.get_surface(1)
+    local surface = game.surfaces[1]
 
     for coord in surface.get_chunks() do
         local X,Y = coord.x, coord.y

--- a/info.json
+++ b/info.json
@@ -1,9 +1,10 @@
 {
     "name": "advanced-logistics-system",
-    "version": "0.2.13",
+    "version": "0.2.14",
+    "factorio_version": "0.13",
     "title": "Advanced Logistics System",
     "author": "anoutsider",
     "description": "Extended Logistics Network View and Monitoring",
     "homepage": "https://github.com/anoutsider/advanced-logistics-system",
-    "dependencies": ["base >= 0.12.12"]
+    "dependencies": ["base >= 0.13.0"]
 }

--- a/prototypes/controller.lua
+++ b/prototypes/controller.lua
@@ -49,6 +49,8 @@ data:extend({
         inventory_size = 0,
         build_distance = 0,
         drop_item_distance = 0,
+        loot_pickup_distance = 0,
+        item_pickup_distance = 0,
         reach_distance = 0,
         reach_resource_distance = 0,
         ticks_to_keep_gun = 0,


### PR DESCRIPTION
Remove deprecated 'defines', refactor game.get_surface(), and set item/loot distances.
