### PR TITLE
Allow god characters to use the "view position" feature

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1130,9 +1130,16 @@ end
 
 --- moves a player ghost to a position and highlights it
 function viewPosition(player, index, position)
-    local ghost = createGhostController(player, position)
+    if player.character then
+        local ghost = createGhostController(player, position)
 
-    changeCharacter(player, ghost)
+        global.character[index] = player.character
+        player.character = ghost
+    else
+        global.character[index] = player.position
+        player.teleport(position)
+    end
+
     hideGUI(player, index)
 
     local locationFlow = player.gui.center.locationFlow
@@ -1145,18 +1152,26 @@ end
 
 --- moves a player back to it's original character and position
 function resetPosition(player, index)
-    local character = global.character[index]
-    if character ~= nil and player.character.name == "ls-controller" then
-        local locationFlow = player.gui.center.locationFlow
-        if locationFlow ~= nil then
-            locationFlow.destroy()
-        end
+    -- this can be a LuaEntity for normal characters or a Position for gods
+    local oldCharacter = global.character[index]
 
-        if changeCharacter(player, character) then
-            global.character[index] = nil
+    if oldCharacter then
+        if player.character and player.character.name == "ls-controller" then
+            player.character.destroy()
+            player.character = oldCharacter
+            showGUI(player, index)
+        elseif player.character == nil then
+            player.teleport(oldCharacter)
         end
-        showGUI(player, index)
     end
+
+    local locationFlow = player.gui.center.locationFlow
+    if locationFlow ~= nil then
+        locationFlow.destroy()
+    end
+
+    global.character[index] = nil
+    showGUI(player, index)
 end
 
 --- creates a new player ghost controller
@@ -1165,20 +1180,6 @@ function createGhostController(player, position)
     local surface = player.surface
     local entity = surface.create_entity({name="ls-controller", position=position, force=player.force})
     return entity
-end
-
---- changes the player character
-function changeCharacter(player, character)
-    if player.character ~= nil and character ~= nil and player.character.valid and character.valid then
-        if player.character.name ~= "ls-controller" then
-            global.character[player.index] = player.character
-        elseif player.character.name == "ls-controller" then
-            player.character.destroy()
-        end
-        player.character = character
-        return true
-    end
-    return false
 end
 
 --- Helper function to get an area where a point intersects with a square

--- a/gui/events.lua
+++ b/gui/events.lua
@@ -7,7 +7,7 @@ script.on_event("ls-toggle-gui", function(event)
 
 	--- reset player position if in location view mode
 	local locationFlow = player.gui.center.locationFlow
-	if locationFlow ~= nil and player.character.name == "ls-controller" then
+	if locationFlow ~= nil then
 		resetPosition(player, index)
 	end
 
@@ -28,7 +28,7 @@ script.on_event("ls-close-gui", function(event)
 	if visible ~= 0 then
 		--- reset player position if in location view mode
 		local locationFlow = player.gui.center.locationFlow
-		if locationFlow ~= nil and player.character.name == "ls-controller" then
+		if locationFlow ~= nil then
 			resetPosition(player, index)
 		end	
 		hideGUI(player, index)
@@ -94,7 +94,7 @@ script.on_event(defines.events.on_gui_click, function(event)
 
         --- reset player position if in location view mode
         local locationFlow = player.gui.center.locationFlow
-        if locationFlow ~= nil and player.character.name == "ls-controller" then
+        if locationFlow ~= nil then
             resetPosition(player, index)
         end
 


### PR DESCRIPTION
This teleports the view for players with no set character
(player.character = nil) rather than use ls-controller which would
lose the player inventory.

The drawback to this is that the player can still move the view when the
location marker is there, but this is not really an issue since the player is
a god anyway.
