### PR TITLE
Call init() before initForce() in on_force_created callback

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -26,6 +26,7 @@ end)
 
 --- Force Related Events
 script.on_event(defines.events.on_force_created, function(event)
+    initAll() -- workaround for https://forums.factorio.com/viewtopic.php?f=7&t=39906
     initForce(event.force)
 end)
 


### PR DESCRIPTION
This is a workaround for this factorio bug:
https://forums.factorio.com/viewtopic.php?f=7&t=39906