### PR TITLE
[0.16] Required changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Forum Link : [Advanced Logistics System](http://www.factorioforums.com/forum/vie
 
 Changelog
 -----
+
+**0.6.0**
+
+  - Upgrade for factorio version 0.16.x - FrancoisH
+
 **0.5.1**
 
   - Upgrade for factorio version 0.15.x - mickael9

--- a/control.lua
+++ b/control.lua
@@ -39,7 +39,7 @@ script.on_event(defines.events.on_robot_built_entity, function(event)
     entityBuilt(event, event.created_entity)
 end)
 
-script.on_event(defines.events.on_preplayer_mined_item, function(event)
+script.on_event(defines.events.on_pre_player_mined_item, function(event)
     entityMined(event, event.entity)
 end)
 

--- a/gui/events.lua
+++ b/gui/events.lua
@@ -335,7 +335,7 @@ script.on_event(defines.events.on_gui_click, function(event)
                 local filterFrame = type == "chests" and filtersFlow.chestsFilterFrame or filtersFlow.typeFilterFrame
                 if filterFrame ~= nil then
 
-                    if style.name == "checkbox_style" then
+                    if style.name == "checkbox" then
                         isSelected = event.element.state
                         type = "group"
                     else
@@ -734,7 +734,7 @@ script.on_event(defines.events.on_gui_click, function(event)
 
         nameLabel.caption = value
         nameEdit.destroy()
-        nameLabel.style = "label_style"
+        nameLabel.style = "label"
 
         event.element.style = "als_button_hidden"
         editBtn.style = "als_button_edit"

--- a/gui/items.lua
+++ b/gui/items.lua
@@ -4,7 +4,7 @@ function updateItemsTable(items, player, index, page, search, sort_by, sort_dir)
         local guiPos = global.settings[index].guiPos
         local currentTab = global.currentTab[index]	
 		local iconsCount = count(global.codeToName[currentTab])
-        local colspan =  iconsCount + 2
+        local column_count =  iconsCount + 2
 		
         if player.gui[guiPos].logisticsFrame ~= nil and player.gui[guiPos].logisticsFrame.contentFrame ~= nil then
 
@@ -72,7 +72,7 @@ function updateItemsTable(items, player, index, page, search, sort_by, sort_dir)
             if player.gui[guiPos].logisticsFrame.contentFrame.itemsFrame.itemsTable ~= nil then
                 player.gui[guiPos].logisticsFrame.contentFrame.itemsFrame.itemsTable.destroy()
             end
-            itemsTable = itemsFrame.add({type = "table", name = "itemsTable", colspan = colspan, style = "als_items_table"})
+            itemsTable = itemsFrame.add({type = "table", name = "itemsTable", column_count = column_count, style = "als_items_table"})
             
             -- set items table dynamic height
             --itemsTable.style.minimal_height = itemsPerPage * 49
@@ -241,7 +241,7 @@ function showItemInfo(item, player, index, page, sort_by, sort_dir)
             end
 
             if chestsCount > 0 then
-                itemInfoTable = itemInfoFrame.add({type ="table", name = "itemInfoTable", colspan = 5, style = "als_items_table"})
+                itemInfoTable = itemInfoFrame.add({type ="table", name = "itemInfoTable", column_count = 5, style = "als_items_table"})
 				
                 -- chest image column
                 itemInfoTable.add({type = "flow", name = "itemInfo_icon", caption = " ", style = "als_icon_flow"})
@@ -414,7 +414,7 @@ function showDisconnectedInfo(player, index, page, sort_by, sort_dir)
                 player.gui[guiPos].logisticsFrame.contentFrame.disconnectedFrame.disconnectedTable.destroy()
             end
 
-            disconnectedTable = disconnectedFrame.add({type ="table", name = "disconnectedTable", colspan = 5, style = "als_items_table"})
+            disconnectedTable = disconnectedFrame.add({type ="table", name = "disconnectedTable", column_count = 5, style = "als_items_table"})
 
             -- chest image column
             disconnectedTable.add({type = "flow", name = "disconnectedInfo_icon", caption = " ", style = "als_icon_flow"})

--- a/gui/network.lua
+++ b/gui/network.lua
@@ -66,7 +66,7 @@ function showNetworksInfo(player, index, page, sort_by, sort_dir)
                 player.gui[guiPos].logisticsFrame.contentFrame.networksFrame.networksTable.destroy()
             end
 
-            networksTable = networksFrame.add({type ="table", name = "networksTable", colspan = 7, style = "als_items_table"})
+            networksTable = networksFrame.add({type ="table", name = "networksTable", column_count = 7, style = "als_items_table"})
 
             -- network name column
             local isSelected = sort_by == 'name'
@@ -159,7 +159,7 @@ function showNetworksInfo(player, index, page, sort_by, sort_dir)
                     local nameFlowValue = nameFlow.add({type = "flow", name = "networkInfoNameValueFL_" .. key, direction = "horizontal", style = "als_network_value_flow"})
                     local nameFlowEdit = nameFlow.add({type = "flow", name = "networkInfoNameEditFL_" .. key, direction = "horizontal"})
 
-                    nameFlowValue.add({type = "label", name = "networkInfoNameLabel_" .. key, caption = name, style = "label_style"})
+                    nameFlowValue.add({type = "label", name = "networkInfoNameLabel_" .. key, caption = name, style = "label"})
                     nameFlowEdit.add({type = "button", name = "networkInfoNameEdit_" .. key, style = "als_button_edit", tooltip = {"tooltips.net-rename"}})
                     nameFlowEdit.add({type = "button", name = "networkInfoNameConfirm_" .. key, style = "als_button_hidden", tooltip = {"tooltips.net-save"}})
 
@@ -261,7 +261,7 @@ function showNetworkInfo(net, player, index, page, sort_by, sort_dir)
                     player.gui[guiPos].logisticsFrame.contentFrame.networkFrame.networkTable.destroy()
                 end
 
-                networkTable = networkFrame.add({type = "table", name = "networkTable", colspan = 8, style = "als_items_table"})
+                networkTable = networkFrame.add({type = "table", name = "networkTable", column_count = 8, style = "als_items_table"})
 
                 -- set items table dynamic height
                 networkTable.style.minimal_height = itemsPerPage * 49
@@ -365,7 +365,7 @@ function showNetworkInfo(net, player, index, page, sort_by, sort_dir)
 
                         local toolsFlow = networkTable["networkInfoTools_" .. key]
                         if toolsFlow == nil then
-                            toolsFlow = networkTable.add({type = "flow", name = "networkInfoTools_" .. key, direction = "horizontal", style = "flow_style"})
+                            toolsFlow = networkTable.add({type = "flow", name = "networkInfoTools_" .. key, direction = "horizontal", style = "horizontal_flow"})
                         end
                         toolsFlow.add({type = "button", name = "networkAction_location_" .. key, style = "als_button_location", tooltip = {"tooltips.tools-location"}})
                         if exTools then toolsFlow.add({type = "button", name = "networkAction_teleport_" .. key, style = "als_button_teleport", tooltip = {"tooltips.tools-teleport"}}) end
@@ -424,26 +424,26 @@ function showNetworksFilter(player, index)
         local searchField = searchFrame.add({type = "textfield", name = "networks-filter-search-field", style = "als_searchfield_style", text = searchText })
 
         -- add all networks option
-        local networksAllTable = networksFilterFrame.add({type = "table", name = "networksAllTable", colspan = 2, style = "als_networks_table"})
+        local networksAllTable = networksFilterFrame.add({type = "table", name = "networksAllTable", column_count = 2, style = "als_networks_table"})
         local allFilter = filtersCount > 0 and "false" or "true"
         local allFilterFlow = networksAllTable.add({type = "flow", name = "allFilterFlow", direction = "horizontal", style = "als_network_filter_flow"})
-        allFilterFlow.add({type = "checkbox", name = "networksFilter_all", style = "checkbox_style", caption = " ", state = allFilter})
+        allFilterFlow.add({type = "checkbox", name = "networksFilter_all", style = "checkbox", caption = " ", state = allFilter})
         local allFilterNameFlow = networksAllTable.add({type = "flow", name = "allFilterNameFlow", direction = "horizontal", style = "als_network_name_flow"})
         allFilterNameFlow.add({type = "label", name = "networksName_all", caption = {"network-all"}, style = "als_info_label"})
 
         -- add networks options
         local networksTableWrapper = networksFilterFrame.add({type = "scroll-pane", name = "networksTableWrapper", style="als_networks_table_wrapper", vertical_scroll_policy = "always"})
-        local networksTable = networksTableWrapper.add({type = "table", name = "networksTable", colspan = 2, style = "als_networks_table"})
+        local networksTable = networksTableWrapper.add({type = "table", name = "networksTable", column_count = 2, style = "als_networks_table"})
 
         local networksFilterFlow = networksTable.add({type = "flow", name = "networkFilterFlow", direction = "horizontal", style = "als_network_filter_flow"})
-        networksFilterFlow.add({type = "label", name = "networksFilterLabel", caption = {"filter"}, style = "label_style"})
+        networksFilterFlow.add({type = "label", name = "networksFilterLabel", caption = {"filter"}, style = "label"})
         local networksFilterNameFlow = networksTable.add({type = "flow", name = "allFilterNameFlow", direction = "horizontal", style = "als_network_name_flow"})
-        networksFilterNameFlow.add({type = "label", name = "networksNameLabel", caption = {"network-name"}, style = "label_style"})
+        networksFilterNameFlow.add({type = "label", name = "networksNameLabel", caption = {"network-name"}, style = "label"})
 
         for key,network in pairs(networks) do
             local name = network.name
             local isFilter = networksFilter[key] and "true" or "false"
-            networksTable.add({type = "checkbox", name = "networksFilter_" .. key, style = "checkbox_style", caption = " ", state = isFilter})
+            networksTable.add({type = "checkbox", name = "networksFilter_" .. key, style = "checkbox", caption = " ", state = isFilter})
             networksTable.add({type = "label", name = "networksName_" .. key, caption = name, style = "als_info_label"})
         end
 
@@ -483,7 +483,7 @@ function updateNetworkFiltersTable(player, index)
                     networksTable[childName].style = "als_network_filter_hidden"
                     networksTable["networksName_" .. key].style = "als_network_name_hidden"
                 else
-                    networksTable[childName].style = "checkbox_style"
+                    networksTable[childName].style = "checkbox"
                     networksTable["networksName_" .. key].style = "als_info_label"
                 end
             end

--- a/gui/settings.lua
+++ b/gui/settings.lua
@@ -8,27 +8,27 @@ function showSettings(player, index)
             player.gui[guiPos].settingsFrame.destroy()
         end
 
-        local settingsFrame = player.gui[guiPos].add({type = "frame", name = "settingsFrame", direction = "vertical", style = "frame_style"})
+        local settingsFrame = player.gui[guiPos].add({type = "frame", name = "settingsFrame", direction = "vertical", style = "frame"})
         settingsFrame.add({type = "label", name = "generalSettings", caption = {"settings.title"}, style = "als_info_label"})
         -- add settings table
         if player.gui[guiPos].settingsFrame.settingsTable ~= nil then
             player.gui[guiPos].settingsFrame.settingsTable.destroy()
         end
 
-        local settingsTable = settingsFrame.add({type ="table", name = "settingsTable", colspan = 3, style = "als_settings_table"})
+        local settingsTable = settingsFrame.add({type ="table", name = "settingsTable", column_count = 3, style = "als_settings_table"})
 
-        settingsTable.add({type = "label", name = "settingsOptionLabel", caption = {"settings.option"}, style = "label_style"})
-        settingsTable.add({type = "label", name = "settingsValueLabel", caption = {"settings.value"}, style = "label_style"})
-        settingsTable.add({type = "label", name = "settingsInfoLabel", caption = {"settings.info"}, style = "label_style"})
+        settingsTable.add({type = "label", name = "settingsOptionLabel", caption = {"settings.option"}, style = "label"})
+        settingsTable.add({type = "label", name = "settingsValueLabel", caption = {"settings.value"}, style = "label"})
+        settingsTable.add({type = "label", name = "settingsInfoLabel", caption = {"settings.info"}, style = "label"})
 
         --- add settings options
         -- gui position
         local guiPosSettings = global.settings[index].guiPos
         settingsTable.add({type = "label", name = "guiPosLabel", caption = {"settings.gui-pos"}, style = "als_info_label"})
         local settingFlow = settingsTable.add({type = "flow", name = "guiPosFlow", direction = "horizontal"})
-        settingFlow.add({type = "checkbox", name = "guiPos_left", style = "checkbox_style", caption = "Left", state = guiPosSettings == "left"})
-        settingFlow.add({type = "checkbox", name = "guiPos_top", style = "checkbox_style", caption = "Top", state = guiPosSettings == "top"})
-        settingFlow.add({type = "checkbox", name = "guiPos_center", style = "checkbox_style", caption = "Center", state = guiPosSettings == "center"})
+        settingFlow.add({type = "checkbox", name = "guiPos_left", style = "checkbox", caption = "Left", state = guiPosSettings == "left"})
+        settingFlow.add({type = "checkbox", name = "guiPos_top", style = "checkbox", caption = "Top", state = guiPosSettings == "top"})
+        settingFlow.add({type = "checkbox", name = "guiPos_center", style = "checkbox", caption = "Center", state = guiPosSettings == "center"})
         settingsTable.add({type = "label", name = "guiPosHelp", caption = {"settings.gui-pos-help"}, style = "als_settings_info_label"})
 
         -- refresh interval
@@ -51,21 +51,21 @@ function showSettings(player, index)
         local autoFilterSettings = global.settings[index].autoFilter
         settingsTable.add({type = "label", name = "autoFilterLabel", caption = {"settings.auto-filter"}, style = "als_info_label"})
         local settingFlow = settingsTable.add({type = "flow", name = "autoFilterFlow", direction = "horizontal"})
-        settingFlow.add({type = "checkbox", name = "autoFilterValue", style = "checkbox_style", caption = {"settings.enable"}, state = autoFilterSettings})
+        settingFlow.add({type = "checkbox", name = "autoFilterValue", style = "checkbox", caption = {"settings.enable"}, state = autoFilterSettings})
         settingsTable.add({type = "label", name = "autoFilterHelp", caption = {"settings.auto-filter-help"}, style = "als_settings_info_label"})
 
         -- exclude requesters
         local excludeReqSettings = global.settings[index].excludeReq
         settingsTable.add({type = "label", name = "excludeReqLabel", caption = {"settings.exclude-req"}, style = "als_info_label"})
         local settingFlow = settingsTable.add({type = "flow", name = "excludeReqFlow", direction = "horizontal"})
-        settingFlow.add({type = "checkbox", name = "excludeReqValue", style = "checkbox_style", caption = {"settings.enable"}, state = excludeReqSettings})
+        settingFlow.add({type = "checkbox", name = "excludeReqValue", style = "checkbox", caption = {"settings.enable"}, state = excludeReqSettings})
         settingsTable.add({type = "label", name = "excludeReqHelp", caption = {"settings.exclude-req-help"}, style = "als_settings_info_label"})
 
         -- experimental tools
         local exToolsSettings = global.settings[index].exTools
         settingsTable.add({type = "label", name = "exToolsLabel", caption = {"settings.ex-tools"}, style = "als_info_label"})
         local settingFlow = settingsTable.add({type = "flow", name = "exToolsFlow", direction = "horizontal"})
-        settingFlow.add({type = "checkbox", name = "exToolsValue", style = "checkbox_style", caption = {"settings.enable"}, state = exToolsSettings})
+        settingFlow.add({type = "checkbox", name = "exToolsValue", style = "checkbox", caption = {"settings.enable"}, state = exToolsSettings})
         settingsTable.add({type = "label", name = "exToolsHelp", caption = {"settings.ex-tools-help"}, style = "als_settings_info_label"})
 
         -- logistics data

--- a/gui/widgets.lua
+++ b/gui/widgets.lua
@@ -96,7 +96,7 @@ function addItemsInfoWidget(player, index)
 
     infoFrame = infoFlow.add({type = "frame", name = currentTab .. "InfoFrame", style = "als_info_frame", direction = "horizontal"})
     infoFrame.add({type = "label", name = currentTab .. "InfoFrameTotalLabel", style = "als_info_label", caption = {"info-total"}})
-    infoFrame.add({type = "label", name = currentTab .. "InfoFrameTotal", style = "label_style", caption = ": " .. number_format(total)})
+    infoFrame.add({type = "label", name = currentTab .. "InfoFrameTotal", style = "label", caption = ": " .. number_format(total)})
 end
 
 --- Show disconnected chests info frame
@@ -130,7 +130,7 @@ function addDisconnectedInfoWidget(player, index)
     if currentTab == "logistics" or currentTab == "disconnected" and disconnectedCount > 0 then
         disconnectedFrame = infoFlow.add({type = "frame", name = "disconnectedFrame", style = "als_info_frame", direction = "horizontal"})
         disconnectedFrame.add({type = "label", name = "disconnectedFrameLabel", style = "als_info_label", caption = {"disconnected-chests"}})
-        disconnectedFrame.add({type = "label", name = "disconnectedFrameTotal", style = "label_style", caption = ": " .. disconnectedCount})
+        disconnectedFrame.add({type = "label", name = "disconnectedFrameTotal", style = "label", caption = ": " .. disconnectedCount})
 		if currentTab == "logistics" then
 			disconnectedFrame.add({type = "button", name = "disconnectedFrameView", caption = {"view"}, style = "als_button_small"})
 		end
@@ -161,7 +161,7 @@ function addNetwroksInfoWidget(player, index, network)
     if currentTab == "logistics" and networksCount > 0 then
         netwroksFrame = infoFlow.add({type = "frame", name = "netwroksFrame", style = "als_info_frame", direction = "horizontal"})
         netwroksFrame.add({type = "label", name = "netwroksFrameLabel", style = "als_info_label", caption = {"networks"}})
-        netwroksFrame.add({type = "label", name = "netwroksFrameTotal", style = "label_style", caption = ": " .. networksCount})
+        netwroksFrame.add({type = "label", name = "netwroksFrameTotal", style = "label", caption = ": " .. networksCount})
         netwroksFrame.add({type = "button", name = "netwroksFrameView", caption = {"view"}, style = "als_button_small"})
     end
 
@@ -171,10 +171,10 @@ function addNetwroksInfoWidget(player, index, network)
         netwroksFrame = infoFlow.add({type = "frame", name = "netwroksFrame", style = "als_info_frame", direction = "horizontal"})
         if currentTab == "networks" then
             netwroksFrame.add({type = "label", name = "netwroksFrameLabel", style = "als_info_label", caption = {"networks"}})
-            netwroksFrame.add({type = "label", name = "netwroksFrameTotal", style = "label_style", caption = ": " .. networksCount})
+            netwroksFrame.add({type = "label", name = "netwroksFrameTotal", style = "label", caption = ": " .. networksCount})
         elseif currentTab == "networkInfo" and network then
             netwroksFrame.add({type = "label", name = "netwroksFrameLabel", style = "als_info_label", caption = {"network-name"}})
-            netwroksFrame.add({type = "label", name = "netwroksFrameTotal", style = "label_style", caption = ": " .. network.name})
+            netwroksFrame.add({type = "label", name = "netwroksFrameTotal", style = "label", caption = ": " .. network.name})
         end
 
         local logFrame = infoFlow["logFrame"]
@@ -232,19 +232,19 @@ function addNetwroksInfoWidget(player, index, network)
 
         logFrame = infoFlow.add({type = "frame", name = "logFrame", style = "als_info_frame", direction = "horizontal"})
         logFrame.add({type = "label", name = "robotsFrameLabelLog", style = "als_info_label", caption = {"network-log"}, tooltip = {"tooltips.net-log-total"}})
-        logFrame.add({type = "label", name = "robotsFrameTotalLog", style = "label_style", caption = ": " .. log_av .. "/" .. log_total})
+        logFrame.add({type = "label", name = "robotsFrameTotalLog", style = "label", caption = ": " .. log_av .. "/" .. log_total})
 
         conFrame = infoFlow.add({type = "frame", name = "conFrame", style = "als_info_frame", direction = "horizontal"})
         conFrame.add({type = "label", name = "robotsFrameLabelCon", style = "als_info_label", caption = {"network-con"}, tooltip = {"tooltips.net-con-total"}})
-        conFrame.add({type = "label", name = "robotsFrameTotalCon", style = "label_style", caption = ": " .. con_av .. "/" .. con_total})
+        conFrame.add({type = "label", name = "robotsFrameTotalCon", style = "label", caption = ": " .. con_av .. "/" .. con_total})
 
         chargingFrame = infoFlow.add({type = "frame", name = "chargingFrame", style = "als_info_frame", direction = "horizontal"})
         chargingFrame.add({type = "label", name = "robotsFrameLabelCharging", style = "als_info_label", caption = {"network-charging"}, tooltip = {"tooltips.net-charging-total"}})
-        chargingFrame.add({type = "label", name = "robotsFrameTotalCharging", style = "label_style", caption = ": " .. charging})
+        chargingFrame.add({type = "label", name = "robotsFrameTotalCharging", style = "label", caption = ": " .. charging})
 
         waitingFrame = infoFlow.add({type = "frame", name = "waitingFrame", style = "als_info_frame", direction = "horizontal"})
         waitingFrame.add({type = "label", name = "robotsFrameLabelWaiting", style = "als_info_label", caption = {"network-waiting"}, tooltip = {"tooltips.net-waiting-total"}})
-        waitingFrame.add({type = "label", name = "robotsFrameTotalWaiting", style = "label_style", caption = ": " .. waiting})
+        waitingFrame.add({type = "label", name = "robotsFrameTotalWaiting", style = "label", caption = ": " .. waiting})
     end
 end
 
@@ -271,7 +271,7 @@ function addItemTotalsInfoWidget(info, player, index)
     -- name
     infoFrameName = infoFlow.add({type = "frame", name = currentTab .. "infoFrameName", style = "als_info_frame", direction = "horizontal"})
     infoFrameName.add({type = "label", name = currentTab .. "infoFrameNameLabel", style = "als_info_label", caption = {"name"}})
-    infoFrameName.add({type = "label", name = currentTab .. "infoFrameNameValue", style = "label_style", caption = getLocalisedName(currentItem)})
+    infoFrameName.add({type = "label", name = currentTab .. "infoFrameNameValue", style = "label", caption = getLocalisedName(currentItem)})
 
 
     --add "all" total info frame
@@ -283,7 +283,7 @@ function addItemTotalsInfoWidget(info, player, index)
     -- all
     infoFrameAll = infoFlow.add({type = "frame", name = currentTab .. "InfoFrameAll", style = "als_info_frame", direction = "horizontal"})
     infoFrameAll.add({type = "label", name = currentTab .. "InfoFrameTotalLabel", style = "als_info_label", caption = {"info-total"}})
-    infoFrameAll.add({type = "label", name = currentTab .. "InfoFrameTotalValue", style = "label_style", caption = ": " .. number_format(total.all)})
+    infoFrameAll.add({type = "label", name = currentTab .. "InfoFrameTotalValue", style = "label", caption = ": " .. number_format(total.all)})
 
     for k,v in spairs(total, orderfunc) do
 		if k ~= "all" then
@@ -296,7 +296,7 @@ function addItemTotalsInfoWidget(info, player, index)
 			if v > 0 then
 				infoFrame = infoFlow.add({type = "frame", name = currentTab .. "InfoFrame" .. key, style = "als_info_frame", direction = "horizontal"})
 				infoFrame.add({type = "label", name = currentTab .. "InfoFrameTotalLabel" .. key, style = "als_info_label", caption = {"info-" .. k}})
-				infoFrame.add({type = "label", name = currentTab .. "InfoFrameValue" .. key, style = "label_style", caption = ": " .. number_format(v)})
+				infoFrame.add({type = "label", name = currentTab .. "InfoFrameValue" .. key, style = "label", caption = ": " .. number_format(v)})
 			end
         end
     end
@@ -323,8 +323,8 @@ function addItemFiltersWidget(player, index)
     local normalState = filters["group"]["normal"] ~= nil
     typeFilterFrame = filtersFlow.add({type = "frame", name = "typeFilterFrame", style = "als_filters_frame", direction = "horizontal"})
     typeFilterFrame.add({type = "label", name = "typeFilterFrameLabel", style = "als_info_label", caption = {"filters"}})
-    typeFilterFrame.add({type = "checkbox", name = "itemInfoFilter_logistics", style = "checkbox_style", caption = {"info-logistics"}, state = logisticsState, tooltip = {"tooltips.filter-by-log"}})
-    typeFilterFrame.add({type = "checkbox", name = "itemInfoFilter_normal", style = "checkbox_style", caption = {"info-normal"}, state = normalState, tooltip = {"tooltips.filter-by-norm"}})
+    typeFilterFrame.add({type = "checkbox", name = "itemInfoFilter_logistics", style = "checkbox", caption = {"info-logistics"}, state = logisticsState, tooltip = {"tooltips.filter-by-log"}})
+    typeFilterFrame.add({type = "checkbox", name = "itemInfoFilter_normal", style = "checkbox", caption = {"info-normal"}, state = normalState, tooltip = {"tooltips.filter-by-norm"}})
 
 
     local chestsFilterFrame = filtersFlow["chestsFilterFrame"]
@@ -421,7 +421,7 @@ function addNetworkFiltersWidget(player, index)
         networkFiltersFrame.add({type = "label", name = "networkFiltersFrameLabel", style = "als_info_label", caption = {"network-filters"}})
 
         if filtersCount == 0 then
-            networkFiltersFrame.add({type = "label", name = "networkFiltersFrameValueAll", style = "label_style", caption = {"network-all"}})
+            networkFiltersFrame.add({type = "label", name = "networkFiltersFrameValueAll", style = "label", caption = {"network-all"}})
             networkFiltersFrame.add({type = "button", name = "networkFiltersFrameView", caption = {"filter"}, style = "als_button_small"})
         else
             networkFiltersFrame.add({type = "label", name = "networkFiltersFrameCount", style = "als_info_label", caption = "(" .. filtersCount .. ")"})

--- a/info.json
+++ b/info.json
@@ -1,10 +1,10 @@
 {
     "name": "advanced-logistics-system",
-    "version": "0.5.1",
-    "factorio_version": "0.15",
+    "version": "0.6.0",
+    "factorio_version": "0.16",
     "title": "Advanced Logistics System",
     "author": "anoutsider",
     "description": "Extended Logistics Network View and Monitoring",
     "homepage": "https://github.com/anoutsider/advanced-logistics-system",
-    "dependencies": ["base >= 0.15.0"]
+    "dependencies": ["base >= 0.16.0"]
 }

--- a/prototypes/controller.lua
+++ b/prototypes/controller.lua
@@ -37,6 +37,7 @@ data:extend({
         type = "player",
         name = "ls-controller",
         icon = "__base__/graphics/icons/player.png",
+        icon_size = 32,
         flags = {"pushable", "placeable-player", "placeable-off-grid", "not-repairable", "not-on-map"},
         max_health = 1,
         healing_per_tick = 0,

--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -4,6 +4,7 @@ data:extend(
         type = "technology",
         name = "advanced-logistics-systems",
         icon = "__advanced-logistics-system__/graphics/technology/advanced-ls.png",
+        icon_size = 32,
         effects ={},
         prerequisites =
         {
@@ -23,8 +24,3 @@ data:extend(
         order = "c-k-c-a",
     }
 })
-
-
-
-
-

--- a/styles/main.lua
+++ b/styles/main.lua
@@ -66,7 +66,7 @@ data.raw["gui-style"].default["als_settings_table"] =
 data.raw["gui-style"].default["als_settings_info_label"] =
 {
     type = "label_style",
-    parent = "label_style",
+    parent = "label",
     align = "left",
     font = "font-s",
 }
@@ -76,7 +76,7 @@ data.raw["gui-style"].default["als_settings_info_label"] =
 data.raw["gui-style"].default["als_location_view"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 100,
     height = 100,
     top_padding = 65,
@@ -145,7 +145,7 @@ data.raw["gui-style"].default["als_frame_hidden"] =
 data.raw["gui-style"].default["als_title_label"] =
 {
     type = "label_style",
-    parent = "label_style",
+    parent = "label",
     width = 708,
     align = "center",
     font = "font-lb",
@@ -214,7 +214,7 @@ data.raw["gui-style"].default["als_search_frame_hidden"] =
 data.raw["gui-style"].default["als_search_label"] =
 {
     type = "label_style",
-    parent = "label_style",
+    parent = "label",
     align = "left",
     top_padding = 0,
     font = "font-mb",
@@ -224,7 +224,7 @@ data.raw["gui-style"].default["als_search_label"] =
 data.raw["gui-style"].default["als_searchfield_style"] =
 {
     type = "textfield_style",
-    parent = "textfield_style",
+    parent = "textfield",
 	height = 20,
 	maximal_height = 20,
 }
@@ -252,7 +252,7 @@ data.raw["gui-style"].default["als_info_frame"] =
 data.raw["gui-style"].default["als_info_label"] =
 {
     type = "label_style",
-    parent = "label_style",
+    parent = "label",
     align = "left",
     font = "font-mb",
     font_color = {r=0.98, g=0.66, b=0.22}
@@ -398,7 +398,7 @@ data.raw["gui-style"].default["als_network_value_flow"] =
 data.raw["gui-style"].default["als_network_name_hidden"] =
 {
     type = "label_style",
-    parent = "label_style",
+    parent = "label",
     visible = false
 }
 
@@ -418,7 +418,7 @@ data.raw["gui-style"].default["als_networks_frame"] =
 data.raw["gui-style"].default["als_networks_table_wrapper"] =
 {
     type = "scroll_pane_style",
-	parent = "scroll_pane_style",
+	parent = "scroll_pane",
 	maximal_height = 400,
 }
 
@@ -463,7 +463,7 @@ data.raw["gui-style"].default["als_network_name_flow"] =
 data.raw["gui-style"].default["als_network_filter_hidden"] =
 {
     type = "checkbox_style",
-    parent = "checkbox_style",
+    parent = "checkbox",
     visible = false
 }
 
@@ -472,7 +472,7 @@ data.raw["gui-style"].default["als_network_filter_hidden"] =
 data.raw["gui-style"].default["als_button"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     top_padding = 3,
     right_padding = 3,
     bottom_padding = 3,
@@ -654,7 +654,7 @@ data.raw["gui-style"].default["als_button_small_selected"] =
 data.raw["gui-style"].default["als_button_main_icon"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     top_padding = 6,
@@ -705,7 +705,7 @@ data.raw["gui-style"].default["als_button_main_icon"] =
 data.raw["gui-style"].default["als_button_close"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     top_padding = 0,
     right_padding = 0,
     bottom_padding = 0,
@@ -756,7 +756,7 @@ data.raw["gui-style"].default["als_button_close"] =
 data.raw["gui-style"].default["als_button_info"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 22,
     height = 23,
     top_padding = 0,
@@ -808,7 +808,7 @@ data.raw["gui-style"].default["als_button_info"] =
 data.raw["gui-style"].default["als_button_location"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 22,
     height = 23,
     top_padding = 0,
@@ -860,7 +860,7 @@ data.raw["gui-style"].default["als_button_location"] =
 data.raw["gui-style"].default["als_button_teleport"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 22,
     height = 23,
     top_padding = 0,
@@ -912,7 +912,7 @@ data.raw["gui-style"].default["als_button_teleport"] =
 data.raw["gui-style"].default["als_button_delete"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 22,
     height = 23,
     top_padding = 0,
@@ -964,7 +964,7 @@ data.raw["gui-style"].default["als_button_delete"] =
 data.raw["gui-style"].default["als_button_delete_selected"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 22,
     height = 23,
     top_padding = 0,
@@ -1016,7 +1016,7 @@ data.raw["gui-style"].default["als_button_delete_selected"] =
 data.raw["gui-style"].default["als_button_up_apc"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 22,
     height = 23,
     top_padding = 0,
@@ -1068,7 +1068,7 @@ data.raw["gui-style"].default["als_button_up_apc"] =
 data.raw["gui-style"].default["als_button_up_ppc"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 22,
     height = 23,
     top_padding = 0,
@@ -1120,7 +1120,7 @@ data.raw["gui-style"].default["als_button_up_ppc"] =
 data.raw["gui-style"].default["als_button_up_sc"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 22,
     height = 23,
     top_padding = 0,
@@ -1173,7 +1173,7 @@ data.raw["gui-style"].default["als_button_up_sc"] =
 data.raw["gui-style"].default["als_button_up_rc"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 22,
     height = 23,
     top_padding = 0,
@@ -1634,7 +1634,7 @@ data.raw["gui-style"].default["als_button_all_selected"] =
 data.raw["gui-style"].default["als_button_apc"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     top_padding = 0,
@@ -1724,7 +1724,7 @@ data.raw["gui-style"].default["als_button_apc_selected"] =
 data.raw["gui-style"].default["als_button_ppc"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     top_padding = 0,
@@ -1814,7 +1814,7 @@ data.raw["gui-style"].default["als_button_ppc_selected"] =
 data.raw["gui-style"].default["als_button_sc"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     top_padding = 0,
@@ -1904,7 +1904,7 @@ data.raw["gui-style"].default["als_button_sc_selected"] =
 data.raw["gui-style"].default["als_button_rc"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     top_padding = 0,
@@ -1994,7 +1994,7 @@ data.raw["gui-style"].default["als_button_rc_selected"] =
 data.raw["gui-style"].default["als_button_woc"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     top_padding = 0,
@@ -2090,7 +2090,7 @@ data.raw["gui-style"].default["als_button_woc_selected"] =
 data.raw["gui-style"].default["als_button_irc"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     top_padding = 0,
@@ -2186,7 +2186,7 @@ data.raw["gui-style"].default["als_button_irc_selected"] =
 data.raw["gui-style"].default["als_button_stc"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     top_padding = 0,
@@ -2282,7 +2282,7 @@ data.raw["gui-style"].default["als_button_stc_selected"] =
 data.raw["gui-style"].default["als_button_log"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     top_padding = 0,
@@ -2378,7 +2378,7 @@ data.raw["gui-style"].default["als_button_log_selected"] =
 data.raw["gui-style"].default["als_button_con"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     top_padding = 0,
@@ -2474,7 +2474,7 @@ data.raw["gui-style"].default["als_button_con_selected"] =
 data.raw["gui-style"].default["als_button_port"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     top_padding = 0,
@@ -2570,7 +2570,7 @@ data.raw["gui-style"].default["als_button_port_selected"] =
 data.raw["gui-style"].default["als_button_edit"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 22,
     height = 23,
     top_padding = 5,
@@ -2623,7 +2623,7 @@ data.raw["gui-style"].default["als_button_edit"] =
 data.raw["gui-style"].default["als_button_confirm"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 22,
     height = 23,
     top_padding = 5,
@@ -2676,7 +2676,7 @@ data.raw["gui-style"].default["als_button_confirm"] =
 data.raw["gui-style"].default["als_button_hidden"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     visible = false,
 }
 
@@ -2685,7 +2685,7 @@ data.raw["gui-style"].default["als_button_hidden"] =
 data.raw["gui-style"].default["als_sort_desc"] =
 {
     type = "frame_style",
-    parent = "frame_style",
+    parent = "frame",
     width = 14,
     height = 14,
     top_padding  = 0,
@@ -2711,7 +2711,7 @@ data.raw["gui-style"].default["als_sort_desc"] =
 data.raw["gui-style"].default["als_sort_asc"] =
 {
     type = "frame_style",
-    parent = "frame_style",
+    parent = "frame",
     width = 14,
     height = 14,
     top_padding  = 0,
@@ -2737,7 +2737,7 @@ data.raw["gui-style"].default["als_sort_asc"] =
 data.raw["gui-style"].default["als_sort"] =
 {
     type = "frame_style",
-    parent = "frame_style",
+    parent = "frame",
     width = 14,
     height = 14,
     top_padding  = 0,
@@ -2763,7 +2763,7 @@ data.raw["gui-style"].default["als_sort"] =
 data.raw["gui-style"].default["als_sort_holder"] =
 {
     type = "frame_style",
-    parent = "frame_style",
+    parent = "frame",
     width = 16,
     height = 9,
     top_padding  = 0,
@@ -2791,7 +2791,7 @@ data.raw["gui-style"].default["als_sort_holder"] =
 data.raw["gui-style"].default["als_item_icon"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 36,
     height = 36,
     scalable = is_scalable,
@@ -2835,7 +2835,7 @@ data.raw["gui-style"].default["als_item_icon"] =
 data.raw["gui-style"].default["als_item_icon_selected"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 36,
     height = 36,
     scalable = is_scalable,
@@ -2880,7 +2880,7 @@ data.raw["gui-style"].default["als_item_icon_selected"] =
 data.raw["gui-style"].default["als_item_icon_small"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     scalable = is_scalable,
@@ -2924,7 +2924,7 @@ data.raw["gui-style"].default["als_item_icon_small"] =
 data.raw["gui-style"].default["als_item_icon_small_selected"] =
 {
     type = "button_style",
-    parent = "button_style",
+    parent = "button",
     width = 32,
     height = 32,
     scalable = is_scalable,

--- a/styles/main.lua
+++ b/styles/main.lua
@@ -232,7 +232,7 @@ data.raw["gui-style"].default["als_searchfield_style"] =
 -- item info
 data.raw["gui-style"].default["als_info_flow"] =
 {
-    type = "flow_style",
+    type = "horizontal_flow_style",
     horizontal_spacing = 2,
     vertical_spacing = 0,
     scalable = is_scalable,
@@ -273,6 +273,7 @@ data.raw["gui-style"].default["als_filters_frame"] =
 
 -- items table headers
 
+-- default flow
 data.raw["gui-style"].default["als_flow_style"] =
 {
     type = "flow_style",
@@ -285,10 +286,36 @@ data.raw["gui-style"].default["als_flow_style"] =
     scalable = is_scalable,
 }
 
+-- horizontal flow
+data.raw["gui-style"].default["als_h_flow_style"] =
+{
+    type = "horizontal_flow_style",
+	horizontal_spacing = 0,
+	vertical_spacing = 0,	
+	top_padding = 0,
+	right_padding = 0,
+	bottom_padding = 0,
+	left_padding = 0,
+    scalable = is_scalable,
+}
+
+-- vertical flow
+data.raw["gui-style"].default["als_v_flow_style"] =
+{
+    type = "vertical_flow_style",
+	horizontal_spacing = 0,
+	vertical_spacing = 0,	
+	top_padding = 0,
+	right_padding = 0,
+	bottom_padding = 0,
+	left_padding = 0,
+    scalable = is_scalable,
+}
+
 data.raw["gui-style"].default["als_table_flow"] =
 {
-    type = "flow_style",
-	parent = "als_flow_style",
+    type = "horizontal_flow_style",
+	parent = "als_h_flow_style",
     horizontal_spacing = 4,
     vertical_spacing = 0,
 	top_padding = 5,
@@ -298,8 +325,8 @@ data.raw["gui-style"].default["als_table_flow"] =
 
 data.raw["gui-style"].default["als_total_flow"] =
 {
-    type = "flow_style",
-	parent = "als_flow_style",
+    type = "horizontal_flow_style",
+	parent = "als_h_flow_style",
     horizontal_spacing = 4,
     vertical_spacing = 0,
 	top_padding = 5,
@@ -309,8 +336,8 @@ data.raw["gui-style"].default["als_total_flow"] =
 
 data.raw["gui-style"].default["als_total_w_flow"] =
 {
-    type = "flow_style",
-	parent = "als_flow_style",
+    type = "horizontal_flow_style",
+	parent = "als_h_flow_style",
     horizontal_spacing = 4,
     vertical_spacing = 0,
 	top_padding = 5,
@@ -320,8 +347,8 @@ data.raw["gui-style"].default["als_total_w_flow"] =
 
 data.raw["gui-style"].default["als_pos_flow"] =
 {
-    type = "flow_style",
-	parent = "als_flow_style",
+    type = "horizontal_flow_style",
+	parent = "als_h_flow_style",
     horizontal_spacing = 4,
     vertical_spacing = 0,
 	top_padding = 5,
@@ -331,8 +358,8 @@ data.raw["gui-style"].default["als_pos_flow"] =
 
 data.raw["gui-style"].default["als_sort_flow"] =
 {
-    type = "flow_style",
-	parent = "als_flow_style",
+    type = "vertical_flow_style",
+	parent = "als_v_flow_style",
     horizontal_spacing = 0,
     vertical_spacing = 0,
 	top_padding = 5,
@@ -342,8 +369,8 @@ data.raw["gui-style"].default["als_sort_flow"] =
 
 data.raw["gui-style"].default["als_icon_flow"] =
 {
-    type = "flow_style",
-	parent = "als_flow_style",
+    type = "horizontal_flow_style",
+	parent = "als_h_flow_style",
     horizontal_spacing = 0,
     vertical_spacing = 0,
 	top_padding = 5,
@@ -353,8 +380,8 @@ data.raw["gui-style"].default["als_icon_flow"] =
 
 data.raw["gui-style"].default["als_name_flow"] =
 {
-    type = "flow_style",
-	parent = "als_flow_style",
+    type = "horizontal_flow_style",
+	parent = "als_h_flow_style",
     horizontal_spacing = 4,
     vertical_spacing = 0,
 	top_padding = 5,
@@ -364,8 +391,8 @@ data.raw["gui-style"].default["als_name_flow"] =
 
 data.raw["gui-style"].default["als_items_info_flow"] =
 {
-    type = "flow_style",
-	parent = "als_flow_style",
+    type = "horizontal_flow_style",
+	parent = "als_h_flow_style",
 	left_padding = 0,
 	right_padding = 0,
 	top_padding = 5,
@@ -375,8 +402,8 @@ data.raw["gui-style"].default["als_items_info_flow"] =
 
 data.raw["gui-style"].default["als_tools_flow"] =
 {
-    type = "flow_style",
-	parent = "als_flow_style",
+    type = "horizontal_flow_style",
+	parent = "als_h_flow_style",
     horizontal_spacing = 6,
     vertical_spacing = 0,
 	left_padding = 0,

--- a/styles/main.lua
+++ b/styles/main.lua
@@ -272,20 +272,6 @@ data.raw["gui-style"].default["als_filters_frame"] =
 }
 
 -- items table headers
-
--- default flow
-data.raw["gui-style"].default["als_flow_style"] =
-{
-    type = "flow_style",
-	horizontal_spacing = 0,
-	vertical_spacing = 0,	
-	top_padding = 0,
-	right_padding = 0,
-	bottom_padding = 0,
-	left_padding = 0,
-    scalable = is_scalable,
-}
-
 -- horizontal flow
 data.raw["gui-style"].default["als_h_flow_style"] =
 {
@@ -416,8 +402,8 @@ data.raw["gui-style"].default["als_tools_flow"] =
 -- Networks 
 data.raw["gui-style"].default["als_network_value_flow"] =
 {
-    type = "flow_style",
-    parent = "als_flow_style",
+    type = "horizontal_flow_style",
+	parent = "als_h_flow_style",
     scalable = is_scalable,
     width = 188,
 }
@@ -469,8 +455,8 @@ data.raw["gui-style"].default["als_networks_table"] =
 
 data.raw["gui-style"].default["als_network_filter_flow"] =
 {
-    type = "flow_style",
-	parent = "als_flow_style",
+    type = "horizontal_flow_style",
+	parent = "als_h_flow_style",
     horizontal_spacing = 0,
     vertical_spacing = 0,
 	top_padding = 5,
@@ -480,8 +466,8 @@ data.raw["gui-style"].default["als_network_filter_flow"] =
 
 data.raw["gui-style"].default["als_network_name_flow"] =
 {
-    type = "flow_style",
-	parent = "als_flow_style",
+    type = "horizontal_flow_style",
+	parent = "als_h_flow_style",
 	top_padding = 5,
     width = 350,
     scalable = is_scalable,


### PR DESCRIPTION
These changes allow the mod to load into Factorio 0.16 up to a new game started... **But:**
- the `type = "flow_style"` should probably be replaced by `horizontal_flow_style` in any `type` that use this one... Except if there's `vertical_flow`. They seems to be differentiated now.
- the `parent = "flow"` should be set in the main style definition, or `horizontal_flow` if required.
- after the flow issue is checked, there's another one with the labels I wasn't able to solve.

So, if you find a way to solve those GUI things, give me a call on Discord  or tell me how you solved it. Hope this will make the updating process easier.